### PR TITLE
Add missing json import in scheduler

### DIFF
--- a/bot/scheduler.py
+++ b/bot/scheduler.py
@@ -1,3 +1,4 @@
+import json
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.date import DateTrigger
 from datetime import datetime


### PR DESCRIPTION
## Summary
- import json in bot/scheduler so job metadata can be serialized

## Testing
- `python -m bot.scheduler` *(fails: No module named 'apscheduler')*

------
https://chatgpt.com/codex/tasks/task_b_68bae31e9f488320b5ba1ad3ba507150