### PR TITLE
Implement admin management and audit logging

### DIFF
--- a/bot/database.py
+++ b/bot/database.py
@@ -4,6 +4,7 @@ from zoneinfo import ZoneInfo
 
 TZ = ZoneInfo(os.getenv("TIMEZONE", "Europe/Berlin"))
 DB_PATH = os.getenv("DB_PATH", "bot.db")
+SUPERADMIN_ID = int(os.getenv("SUPERADMIN_ID", "0"))
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS admins (user_id INTEGER PRIMARY KEY);
@@ -34,9 +35,35 @@ def init_db():
     return DB
 
 def is_admin(uid: int) -> bool:
-    if uid == int(os.getenv("SUPERADMIN_ID", "0")):
+    if uid == SUPERADMIN_ID:
         return True
     cur = DB.execute("SELECT 1 FROM admins WHERE user_id=?", (uid,))
     return cur.fetchone() is not None
 
-# … функции add_admin, remove_admin, list_admins, audit …
+
+def audit(user_id: int | None, action: str, target: str | None = None, details: str | None = None) -> None:
+    ts = int(datetime.now(TZ).timestamp())
+    DB.execute(
+        "INSERT INTO audit_logs (ts, user_id, action, target, details) VALUES (?, ?, ?, ?, ?)",
+        (ts, user_id, action, target, json.dumps(details) if isinstance(details, (dict, list)) else details),
+    )
+    DB.commit()
+
+
+def add_admin(uid: int, actor: int | None = None) -> bool:
+    cur = DB.execute("INSERT OR IGNORE INTO admins (user_id) VALUES (?)", (uid,))
+    audit(actor, "add_admin", target=str(uid))
+    return cur.rowcount > 0
+
+
+def remove_admin(uid: int, actor: int | None = None) -> bool:
+    cur = DB.execute("DELETE FROM admins WHERE user_id=?", (uid,))
+    audit(actor, "remove_admin", target=str(uid))
+    return cur.rowcount > 0
+
+
+def list_admins(actor: int | None = None) -> list[int]:
+    cur = DB.execute("SELECT user_id FROM admins ORDER BY user_id")
+    rows = [r[0] for r in cur.fetchall()]
+    audit(actor, "list_admins")
+    return rows

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,36 @@
+import os
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def db():
+    os.environ["DB_PATH"] = ":memory:"
+    import bot.database as database
+    importlib.reload(database)
+    database.init_db()
+    return database
+
+
+def test_add_and_remove_admin(db):
+    assert db.list_admins(actor=1) == []
+    assert db.add_admin(42, actor=1) is True
+    assert db.list_admins(actor=1) == [42]
+    assert db.remove_admin(42, actor=1) is True
+    assert db.list_admins(actor=1) == []
+
+
+def test_audit_logging(db):
+    db.add_admin(7, actor=99)
+    db.list_admins(actor=99)
+    db.remove_admin(7, actor=99)
+    rows = db.DB.execute(
+        "SELECT action, target, user_id FROM audit_logs ORDER BY id"
+    ).fetchall()
+    assert rows == [
+        ("add_admin", "7", 99),
+        ("list_admins", None, 99),
+        ("remove_admin", "7", 99),
+    ]
+


### PR DESCRIPTION
## Summary
- Implement admin management helpers and audit logging in `bot/database.py`
- Add pytest suite validating admin addition/removal and audit log entries

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bae320c2608320b1e17456e281b346