### PR TITLE
Add HR email parsing and tests

### DIFF
--- a/ai/nlp.py
+++ b/ai/nlp.py
@@ -6,7 +6,12 @@ kata we only need very small parsing capabilities which are implemented here.
 
 from __future__ import annotations
 
+import email.message
+import re
+from datetime import datetime
 from typing import List, Tuple
+
+from dateparser.search import search_dates
 
 
 ALIASES = {
@@ -48,5 +53,56 @@ def parse_command(text: str) -> Tuple[str, List[str]]:
     return "", [text]
 
 
-__all__ = ["parse_command"]
+def parse_hr_mail(msg: email.message.Message) -> tuple[str | None, datetime | None]:
+    """Extract employee name and dismissal date from an HR e-mail.
+
+    Parameters
+    ----------
+    msg:
+        ``email.message.Message`` instance representing the incoming e-mail.
+
+    Returns
+    -------
+    tuple(fio, date)
+        * fio -- extracted full name or ``None`` when not found.
+        * date -- parsed ``datetime`` object or ``None`` when not found.
+    """
+
+    # Extract plain text payload from the message
+    parts: List[str] = []
+    if msg.is_multipart():
+        for part in msg.walk():
+            if part.get_content_type() == "text/plain":
+                payload = part.get_payload(decode=True)
+                if payload:
+                    charset = part.get_content_charset() or "utf-8"
+                    parts.append(payload.decode(charset, errors="ignore"))
+    else:
+        payload = msg.get_payload(decode=True)
+        if isinstance(payload, bytes):
+            parts.append(payload.decode(msg.get_content_charset() or "utf-8", errors="ignore"))
+        elif isinstance(payload, str):
+            parts.append(payload)
+
+    body = "\n".join(parts)
+
+    # Extract FIO (full name) - three capitalized words
+    fio: str | None = None
+    match = re.search(r"([А-ЯЁ][а-яё]+\s+[А-ЯЁ][а-яё]+\s+[А-ЯЁ][а-яё]+)", body)
+    if match:
+        fio = match.group(1).strip()
+
+    # Extract first date occurrence using dateparser
+    date: datetime | None = None
+    try:
+        found = search_dates(body, languages=["ru"])
+    except Exception:
+        found = None
+    if found:
+        date = found[0][1]
+
+    return fio, date
+
+
+__all__ = ["parse_command", "parse_hr_mail"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,2 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_nlp.py
+++ b/tests/test_nlp.py
@@ -1,0 +1,21 @@
+from email.message import EmailMessage
+from datetime import datetime
+
+from ai.nlp import parse_hr_mail
+
+
+def test_parse_hr_mail_valid():
+    msg = EmailMessage()
+    msg.set_content("Просьба уволить Иванов Иван Иванович 1 июля 2024")
+    fio, date = parse_hr_mail(msg)
+    assert fio == "Иванов Иван Иванович"
+    assert isinstance(date, datetime)
+    assert date.date() == datetime(2024, 7, 1).date()
+
+
+def test_parse_hr_mail_invalid():
+    msg = EmailMessage()
+    msg.set_content("Неразборчивое письмо без нужных данных")
+    fio, date = parse_hr_mail(msg)
+    assert fio is None
+    assert date is None


### PR DESCRIPTION
## Summary
- implement `parse_hr_mail` to extract employee name and termination date from plain text HR emails using regex and `dateparser`
- add unit tests for valid and invalid HR email formats
- ensure test suite imports project modules by extending `sys.path`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateparser')*

------
https://chatgpt.com/codex/tasks/task_b_68bae6f62ee4832087becc8d379dc2ae