### PR TITLE
Implement admin callback menu and tests

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,0 +1,2 @@
+"""Bot package."""
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Ensure project root is importable
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture(autouse=True)
+def fake_telegram_modules(monkeypatch):
+    """Provide minimal telegram stubs if library is missing."""
+
+    try:  # pragma: no cover - real library present
+        import telegram  # type: ignore
+        import telegram.ext  # type: ignore
+        return
+    except Exception:
+        pass
+
+    telegram = types.ModuleType("telegram")
+
+    class Dummy:
+        def __init__(self, *a, **kw):
+            pass
+
+    telegram.Update = Dummy
+    telegram.ReplyKeyboardMarkup = Dummy
+    telegram.InlineKeyboardButton = Dummy
+    telegram.InlineKeyboardMarkup = Dummy
+    sys.modules["telegram"] = telegram
+
+    ext = types.ModuleType("telegram.ext")
+    ext.CommandHandler = Dummy
+    ext.MessageHandler = Dummy
+    ext.CallbackQueryHandler = Dummy
+    ext.filters = types.SimpleNamespace(TEXT=None, COMMAND=None)
+    sys.modules["telegram.ext"] = ext
+

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,73 @@
+import types
+import asyncio
+
+import pytest
+
+
+class DummyQuery:
+    def __init__(self, data, user_id):
+        self.data = data
+        self.from_user = types.SimpleNamespace(id=user_id)
+        self.answered = None
+
+    async def answer(self, text, show_alert=False):
+        self.answered = text
+
+
+def test_super_cb_add_admin(monkeypatch):
+    import bot.handlers as h
+
+    called = {}
+
+    def fake_add(uid, actor=None):
+        called["args"] = (uid, actor)
+        return True
+
+    monkeypatch.setattr(h, "add_admin", fake_add)
+    monkeypatch.setattr(h, "SUPERADMIN_ID", 1)
+
+    q = DummyQuery("super:add:42", user_id=1)
+    update = types.SimpleNamespace(callback_query=q, effective_user=q.from_user)
+
+    asyncio.run(h.super_cb(update, None))
+
+    assert called["args"] == (42, 1)
+
+def test_super_cb_remove_requires_superadmin(monkeypatch):
+    import bot.handlers as h
+
+    called = {}
+
+    def fake_remove(uid, actor=None):
+        called["args"] = (uid, actor)
+        return True
+
+    monkeypatch.setattr(h, "remove_admin", fake_remove)
+    monkeypatch.setattr(h, "SUPERADMIN_ID", 1)
+
+    q = DummyQuery("super:remove:42", user_id=2)
+    update = types.SimpleNamespace(callback_query=q, effective_user=q.from_user)
+
+    asyncio.run(h.super_cb(update, None))
+
+    assert called == {}
+
+def test_super_cb_remove_admin(monkeypatch):
+    import bot.handlers as h
+
+    called = {}
+
+    def fake_remove(uid, actor=None):
+        called["args"] = (uid, actor)
+        return True
+
+    monkeypatch.setattr(h, "remove_admin", fake_remove)
+    monkeypatch.setattr(h, "SUPERADMIN_ID", 1)
+
+    q = DummyQuery("super:remove:7", user_id=1)
+    update = types.SimpleNamespace(callback_query=q, effective_user=q.from_user)
+
+    asyncio.run(h.super_cb(update, None))
+
+    assert called["args"] == (7, 1)
+


### PR DESCRIPTION
## Summary
- add inline admin menu and callbacks for adding/removing/listing admins
- confirm reset/disable actions and enforce permission checks
- add tests for admin management callbacks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bae6ff58f88320b2db50796f5021a8