### PR TITLE
Mark processed mails as seen and add IMAP tests

### DIFF
--- a/bot/mail_checker.py
+++ b/bot/mail_checker.py
@@ -18,10 +18,14 @@ async def start_mail_checker():
                 for num in data[0].split():
                     typ, msg_data = M.fetch(num, "(RFC822)")
                     msg = email.message_from_bytes(msg_data[0][1])
+                    msg_id = msg.get("Message-ID", num.decode())
+                    logging.info("Processing mail %s", msg_id)
                     fio, date = parse_hr_mail(msg)
                     if fio and date:
                         run_dt = date.replace(hour=16, minute=0, second=0, tzinfo=TZ)
                         schedule_disable_job(fio, run_dt, created_by=0, meta={"source": "mail"})
+                        M.store(num, "+FLAGS", "\\Seen")
+                        logging.info("Processed mail %s", msg_id)
         except Exception:
             logging.exception("IMAP poll error")
         await asyncio.sleep(int(os.getenv("IMAP_POLL_SECONDS", "300")))

--- a/tests/test_mail_checker.py
+++ b/tests/test_mail_checker.py
@@ -1,0 +1,81 @@
+import asyncio
+import logging
+from email.message import EmailMessage
+from datetime import datetime
+import types
+import sys
+
+import pytest
+
+# Provide stub scheduler module for import in mail_checker
+sys.modules['scheduler'] = types.SimpleNamespace(schedule_disable_job=lambda *a, **k: None)
+sys.modules['db'] = types.SimpleNamespace()
+sys.modules['db.database'] = types.SimpleNamespace(TZ=None)
+
+import bot.mail_checker as mc
+
+
+class FakeIMAP:
+    def __init__(self):
+        self.messages = {
+            b"1": {"flags": set(), "msg": self._make_msg("<id1>")},
+            b"2": {"flags": {"\\Seen"}, "msg": self._make_msg("<id2>")},
+        }
+
+    def _make_msg(self, msg_id: str) -> bytes:
+        m = EmailMessage()
+        m["Message-ID"] = msg_id
+        m.set_content("test")
+        return m.as_bytes()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def login(self, user, pwd):
+        pass
+
+    def select(self, folder):
+        pass
+
+    def search(self, charset, criteria):
+        unseen = [num.decode() for num, data in self.messages.items() if "\\Seen" not in data["flags"]]
+        return "OK", [" ".join(unseen).encode()]
+
+    def fetch(self, num, parts):
+        return "OK", [(b"1", self.messages[num]["msg"])]
+
+    def store(self, num, cmd, flags):
+        self.messages[num]["flags"].add(flags)
+        return "OK", []
+
+
+def test_mail_checker_marks_seen(monkeypatch, caplog):
+    fake = FakeIMAP()
+    monkeypatch.setenv("IMAP_HOST", "host")
+    monkeypatch.setenv("IMAP_USER", "user")
+    monkeypatch.setenv("IMAP_PASS", "pass")
+
+    monkeypatch.setattr(mc.imaplib, "IMAP4_SSL", lambda host: fake)
+    monkeypatch.setattr(mc, "parse_hr_mail", lambda msg: ("User", datetime(2024, 1, 1)))
+
+    scheduled = []
+    monkeypatch.setattr(
+        mc, "schedule_disable_job", lambda *args, **kwargs: scheduled.append(args)
+    )
+
+    async def fake_sleep(_):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(mc.asyncio, "sleep", fake_sleep)
+
+    caplog.set_level(logging.INFO)
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(mc.start_mail_checker())
+
+    assert "\\Seen" in fake.messages[b"1"]["flags"]
+    assert fake.messages[b"2"]["flags"] == {"\\Seen"}
+    assert len(scheduled) == 1
+    assert any("id1" in msg for msg in caplog.messages)


### PR DESCRIPTION
## Summary
- log message IDs and mark processed mail as seen
- add an integration test simulating an IMAP inbox with seen/unseen mails

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68baeb58b7548320bc75a3aa4895fbde