### PR TITLE
Ensure DB initialization and add missing tests

### DIFF
--- a/bot/database.py
+++ b/bot/database.py
@@ -34,36 +34,47 @@ def init_db():
     DB.execute("PRAGMA journal_mode=WAL")
     return DB
 
+
+def _ensure_db() -> sqlite3.Connection:
+    if DB is None:
+        raise RuntimeError("Database is not initialized. Call init_db() first.")
+    return DB
+
 def is_admin(uid: int) -> bool:
+    db = _ensure_db()
     if uid == SUPERADMIN_ID:
         return True
-    cur = DB.execute("SELECT 1 FROM admins WHERE user_id=?", (uid,))
+    cur = db.execute("SELECT 1 FROM admins WHERE user_id=?", (uid,))
     return cur.fetchone() is not None
 
 
 def audit(user_id: int | None, action: str, target: str | None = None, details: str | None = None) -> None:
+    db = _ensure_db()
     ts = int(datetime.now(TZ).timestamp())
-    DB.execute(
+    db.execute(
         "INSERT INTO audit_logs (ts, user_id, action, target, details) VALUES (?, ?, ?, ?, ?)",
         (ts, user_id, action, target, json.dumps(details) if isinstance(details, (dict, list)) else details),
     )
-    DB.commit()
+    db.commit()
 
 
 def add_admin(uid: int, actor: int | None = None) -> bool:
-    cur = DB.execute("INSERT OR IGNORE INTO admins (user_id) VALUES (?)", (uid,))
+    db = _ensure_db()
+    cur = db.execute("INSERT OR IGNORE INTO admins (user_id) VALUES (?)", (uid,))
     audit(actor, "add_admin", target=str(uid))
     return cur.rowcount > 0
 
 
 def remove_admin(uid: int, actor: int | None = None) -> bool:
-    cur = DB.execute("DELETE FROM admins WHERE user_id=?", (uid,))
+    db = _ensure_db()
+    cur = db.execute("DELETE FROM admins WHERE user_id=?", (uid,))
     audit(actor, "remove_admin", target=str(uid))
     return cur.rowcount > 0
 
 
 def list_admins(actor: int | None = None) -> list[int]:
-    cur = DB.execute("SELECT user_id FROM admins ORDER BY user_id")
+    db = _ensure_db()
+    cur = db.execute("SELECT user_id FROM admins ORDER BY user_id")
     rows = [r[0] for r in cur.fetchall()]
     audit(actor, "list_admins")
     return rows

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -13,6 +13,22 @@ def db():
     return database
 
 
+def test_requires_init():
+    os.environ["DB_PATH"] = ":memory:"
+    import bot.database as database
+    importlib.reload(database)
+    funcs = [
+        lambda: database.is_admin(1),
+        lambda: database.add_admin(1),
+        lambda: database.remove_admin(1),
+        lambda: database.list_admins(),
+        lambda: database.audit(None, "x"),
+    ]
+    for fn in funcs:
+        with pytest.raises(RuntimeError, match="Database is not initialized"):
+            fn()
+
+
 def test_add_and_remove_admin(db):
     assert db.list_admins(actor=1) == []
     assert db.add_admin(42, actor=1) is True


### PR DESCRIPTION
## Summary
- add `_ensure_db` helper that raises a clear error when the DB is not initialized
- call `_ensure_db` at the start of database operations to prevent usage without initialization
- test that using any database function before `init_db` raises the expected exception

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68baec3ff8d88320b1b41efd1b2117cd