### PR TITLE
Use package entry point for bot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY bot ./bot
 COPY ai ./ai
 
-CMD ["python", "bot/main.py"]
+CMD ["python", "-m", "bot.main"]


### PR DESCRIPTION
## Summary
- run bot via `python -m bot.main` so module path includes /app and packages like `ai` are visible

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68baef0b8c548320b22377759bdcc06b