### PR TITLE
docs: document manual start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,17 @@
 docker compose build
 docker compose up -d
 ```
+
+## Manual run
+
+Start the bot directly without Docker:
+
+```bash
+python -m bot.main
+```
+
+If you run the container manually and override the default command, use the same module form:
+
+```bash
+docker run <image> python -m bot.main
+```


### PR DESCRIPTION
## Summary
- confirm Dockerfile uses python -m bot.main to start bot
- add manual run instructions for launching with python -m bot.main

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bb030c0ac083208ae5e691b9598b91